### PR TITLE
Gradle 8.2.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=03ec176d388f2aa99defcadc3ac6adf8dd2bce5145a129659537c0874dea5ad1


### PR DESCRIPTION
Updates to Gradle 8.2.1 ([release notes](https://docs.gradle.org/8.2.1/release-notes.html))

Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.gradle.UpdateGradleWrapper?defaults=W3sibmFtZSI6InZlcnNpb24iLCJ2YWx1ZSI6IjguMi4xIn0seyJuYW1lIjoiZGlzdHJpYnV0aW9uIiwidmFsdWUiOiJiaW4ifSx7Im5hbWUiOiJhZGRJZk1pc3NpbmciLCJ2YWx1ZSI6IkZhbHNlIn1d&organizationId=R3JhZGxlIFBsdWdpbnM%3D